### PR TITLE
Blocking queue implementation for PrefixLoader

### DIFF
--- a/src/com/humboldtjs/utility/Animator.as
+++ b/src/com/humboldtjs/utility/Animator.as
@@ -101,6 +101,22 @@ package com.humboldtjs.utility
 		}
 		
 		/**
+		 * Stops the current animation.
+		 */
+		public function stop():void
+		{
+			for (var i:int = mAnimationMap.length - 1; i >= 0; i--) {
+				mAnimationMap.splice(i, 1);				
+			}
+			
+			if (mTimer > -1)
+			{
+				window.clearTimeout(mTimer);
+				mTimer = -1;
+			}
+		}
+		
+		/**
 		 * The main animation loop. Processes all currently running animations.
 		 */
 		protected function animationLoop():void

--- a/src/com/humboldtjs/xml/XMLComplex.as
+++ b/src/com/humboldtjs/xml/XMLComplex.as
@@ -49,7 +49,8 @@ package com.humboldtjs.xml
 					if (aValue[i] is HJSXML) {
 						mValue.push(aValue[i]);
 					} else {
-						mValue.push(processXML(aValue[i]));
+						if (typeof aValue[i] !== "undefined")
+							mValue.push(processXML(aValue[i]));
 					}
 				}
 			}


### PR DESCRIPTION
This implementation extends the PrefixLoader with a Queue to avoid problems that arise when using multiple prefixloaders. Since after content has been loaded we can't get the origin anymore you couldn't just rely on the first callback being the one who requested the content. We store this login in the window object with the proper prefix and matching load queue suffix because referencing to the object statically won't work in javascript properly.

Removed onCallback and rather use doCallback for handling the callback, which in turn triggers the queue handler loadNextIfAvailable.
