### PR TITLE
- added the animation object to the callback function when an animation ...

### DIFF
--- a/src/com/humboldtjs/display/Stage.as
+++ b/src/com/humboldtjs/display/Stage.as
@@ -81,7 +81,9 @@ package com.humboldtjs.display
 			
 			var theFunctions:Array = new Array("requestAnimationFrame", "webkitRequestAnimationFrame", "mozRequestAnimationFrame", "oRequestAnimationFrame", "msRequestAnimationFrame");
 			for (var i:int = 0; i < theFunctions.length; i++) {
-				if (window[theFunctions[i]] != null) _requestAnimationFrame = theFunctions[i];
+				if (window[theFunctions[i]] != null && _requestAnimationFrame == "") {
+					_requestAnimationFrame = theFunctions[i];
+				}
 			}
 
 			// start the frame loop

--- a/src/com/humboldtjs/utility/Animator.as
+++ b/src/com/humboldtjs/utility/Animator.as
@@ -31,6 +31,16 @@ package com.humboldtjs.utility
 		
 		public var ease:Function;
 		
+		public function getTarget():*
+		{
+			return _object;
+		}
+		
+		public function isAnimating():Boolean
+		{
+			return _animationMap.length > 0;
+		}
+		
 		/**
 		 * @constructor
 		 */
@@ -206,7 +216,7 @@ package com.humboldtjs.utility
 				if (theAnimation.position >= 1) {
 					_animationMap.splice(i, 1);
 					if (theAnimation.complete) {
-						theAnimation.complete();
+						theAnimation.complete(this);
 					}
 				}
 			}


### PR DESCRIPTION
- added the animation object to the callback function when an animation is done so the caller can clean up / be referenced
- in case of multiple property animations check if the Animator is still busy, to prevent cleanup if necessary
- added getTarget to retrieve the Animators object its animating
- fixed the requestAnimationFrame / webkitRequestAnimationFrame routine. It now properly selects the first applicable function found on the DOM instead of always the last
